### PR TITLE
Update packages

### DIFF
--- a/src/PdfLibCore.FreeImage/PdfLibCore.FreeImage.csproj
+++ b/src/PdfLibCore.FreeImage/PdfLibCore.FreeImage.csproj
@@ -55,7 +55,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MinVer" Version="4.0.0">
+      <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/PdfLibCore.ImageSharp/PdfLibCore.ImageSharp.csproj
+++ b/src/PdfLibCore.ImageSharp/PdfLibCore.ImageSharp.csproj
@@ -54,7 +54,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="MinVer" Version="4.0.0">
+      <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/PdfLibCore.MagickNet/PdfLibCore.MagickNet.csproj
+++ b/src/PdfLibCore.MagickNet/PdfLibCore.MagickNet.csproj
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="11.1.2" />
+      <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>
@@ -54,7 +54,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MinVer" Version="4.0.0">
+      <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/PdfLibCore.SkiaSharp/PdfLibCore.SkiaSharp.csproj
+++ b/src/PdfLibCore.SkiaSharp/PdfLibCore.SkiaSharp.csproj
@@ -35,8 +35,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SkiaSharp" Version="2.88.0" />
-      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0" />
+      <PackageReference Include="SkiaSharp" Version="2.88.3" />
+      <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -55,7 +55,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="MinVer" Version="4.0.0">
+      <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/PdfLibCore/PdfLibCore.csproj
+++ b/src/PdfLibCore/PdfLibCore.csproj
@@ -74,10 +74,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="bblanchon.PDFium.Linux" Version="107.0.5268" />
-      <PackageReference Include="bblanchon.PDFium.macOS" Version="107.0.5268" />
-      <PackageReference Include="bblanchon.PDFium.Win32" Version="107.0.5268" />
-      <PackageReference Include="MinVer" Version="4.0.0">
+      <PackageReference Include="bblanchon.PDFium.Linux" Version="114.0.5677" />
+      <PackageReference Include="bblanchon.PDFium.macOS" Version="114.0.5677" />
+      <PackageReference Include="bblanchon.PDFium.Win32" Version="114.0.5677" />
+      <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/UnitTests/PdfLibCore.UnitTests/PdfLibCore.UnitTests.csproj
+++ b/src/UnitTests/PdfLibCore.UnitTests/PdfLibCore.UnitTests.csproj
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="FluentAssertions" Version="6.10.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+      <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updated NuGet packages.
Updating the packages from bblanchon.PDFium.Linux, bblanchon.PDFium.maxOs and bblanchon.PDFium.Win32 resolved a lot of AccessViolationExceptions.